### PR TITLE
Update to 2.4.7

### DIFF
--- a/common.c
+++ b/common.c
@@ -30,10 +30,10 @@
 
 #include "common.h"
 
+#define BUFFSIZE 256
+
 int debug = 0;
 int debug_to_syslog = 0;
-
-#define BUFFSIZE 256
 
 /* This used to be needed on older versions of cygwin */
 #if 0
@@ -43,199 +43,196 @@ int debug_to_syslog = 0;
 #endif
 
 void random_string(char *buffer, size_t bufflen)
-{ 
-	char *buffptr = buffer + bufflen - 1; 
+{
+	char *buffptr = buffer + bufflen - 1;
 	*buffptr = '\0';
-  
-	while(--buffptr >= buffer) { 
-		/* Random character code lifted from salt generation stuff   */ 
-		/* Using random because of historical problems with low bits */ 
-		/* in rand()                                                 */ 
+
+	while(--buffptr >= buffer) {
+		/* Random character code lifted from salt generation stuff   */
+		/* Using random because of historical problems with low bits */
+		/* in rand()                                                 */
 		*buffptr = (char) (random() & 077);
-    
-		*buffptr += 46;                   /* . character */ 
-		if (*buffptr > 57) *buffptr += 7; /* 9 character */ 
-		if (*buffptr > 90) *buffptr += 6; /* Z character */ 
+
+		*buffptr += 46;                   /* . character */
+		if (*buffptr > 57) *buffptr += 7; /* 9 character */
+		if (*buffptr > 90) *buffptr += 6; /* Z character */
 	}
 }
 
 
+void dbg(char *fmt, ...)
+{
+	va_list args;
+
+	if (debug) {
+		char buffer[BUFFSIZE];
+
+		memset(buffer, 0, BUFFSIZE);
+		strcat(buffer, "DEBUG: ");
+		va_start(args, fmt);
+		vsnprintf(buffer, BUFFSIZE, fmt, args);
+		va_end(args);
+
+		if (debug_to_syslog) {
+			syslog(LOG_DEBUG, buffer);
+		}
+		else {
+			printf(buffer);
+		}
+	}
+}
+
 
 /* Not really /common/ but all this sorta junk is going in common.c */
 char *ask_user(char *question)
-{ 
-	char buffer[BUFFSIZE]; 
+{
+	char buffer[BUFFSIZE];
 	char *result = NULL;
-  
-	printf(question); 
+
+	printf(question);
 	fflush(stdout);
-  
-	if (fgets(buffer, BUFFSIZE, stdin) != NULL) { 
-		chomp(buffer); 
-		result = strdup(buffer); 
+
+	if (fgets(buffer, BUFFSIZE, stdin) != NULL) {
+		chomp(buffer);
+		result = strdup(buffer);
 	}
-  
+
 	return result;
 }
 
 
 char *recv_sock(int fd)
-{ 
-	int nread; 
-	char buffer[BUFFSIZE]; 
+{
+	int nread;
+	char buffer[BUFFSIZE];
 
 	memset(&buffer, 0, BUFFSIZE);
-  
-	if ((nread = read(fd, &buffer, BUFFSIZE - 1)) < 0) { 
-		perror("read()"); 
-		return NULL; 
+
+	if ((nread = read(fd, &buffer, BUFFSIZE - 1)) < 0) {
+		perror("read()");
+		return NULL;
 	}
-  
-	if (nread == 0) { 
-		syslog(LOG_INFO, "read(): EOF on socket.\n"); 
-		return NULL; 
+
+	if (nread == 0) {
+		syslog(LOG_INFO, "read(): EOF on socket.\n");
+		return NULL;
 	}
-  
+
 	chomp(buffer);
-  
+
 	dbg("Received: '%s'\n", buffer);
-  
+
 	return strdup(buffer);
 }
 
 
 void send_sock(int fd, char *fmt, ...)
-{ 
-	char buffer[BUFFSIZE]; 
+{
+	char buffer[BUFFSIZE];
 	va_list args;
-  
-	va_start(args, fmt); 
-	vsnprintf(buffer, BUFFSIZE, fmt, args); 
+
+	va_start(args, fmt);
+	vsnprintf(buffer, BUFFSIZE, fmt, args);
 	va_end(args);
-  
+
 	dbg("Sending '%s'\n", buffer);
-  
+
 	write(fd, buffer, strlen(buffer));
 }
 
 
 void chomp(char *string)
-{ 
+{
 	char *c;
-  
-	if ((c = index(string, '\n')) != NULL) { 
-		*c = '\0'; 
+
+	if ((c = index(string, '\n')) != NULL) {
+		*c = '\0';
 	}
-  
-	if ((c = index(string, '\r')) != NULL) { 
-		*c = '\0'; 
+
+	if ((c = index(string, '\r')) != NULL) {
+		*c = '\0';
 	}
 }
 
 
 int do_sha(char *string, unsigned char **digest)
-{ 
+{
 	SHA_CTX context;
-  
-	if ((*digest = (unsigned char *) malloc(SHA_DIGEST_LENGTH)) == NULL) { 
-		return 0; 
+
+	if ((*digest = (unsigned char *) malloc(SHA_DIGEST_LENGTH)) == NULL) {
+		return 0;
 	}
-  
-	SHA1_Init(&context); 
-	SHA1_Update(&context, string, strlen(string)); 
+
+	SHA1_Init(&context);
+	SHA1_Update(&context, string, strlen(string));
 	SHA1_Final(*digest, &context);
-  
+
 	return SHA_DIGEST_LENGTH;
 }
 
 
 int do_md5(char *string, unsigned char **digest)
-{ 
+{
 	MD5_CTX context;
-  
-	if ((*digest = (unsigned char *) malloc(MD5_DIGEST_LENGTH)) == NULL) { 
-		return 0; 
+
+	if ((*digest = (unsigned char *) malloc(MD5_DIGEST_LENGTH)) == NULL) {
+		return 0;
 	}
-  
-	MD5_Init(&context); 
-	MD5_Update(&context, string, strlen(string)); 
+
+	MD5_Init(&context);
+	MD5_Update(&context, string, strlen(string));
 	MD5_Final(*digest, &context);
-  
+
 	return MD5_DIGEST_LENGTH;
 }
 
 
 char *hash(int version, char *fmt, ...)
-{ 
-	char *result, *tmp, string[BUFFSIZE]; 
-	unsigned char *hash; 
-	int         i, hashsize = 0; 
+{
+	char *result, *tmp, string[BUFFSIZE];
+	unsigned char *hash;
+	int         i, hashsize = 0;
 	va_list args;
-  
-	va_start(args, fmt); 
-	vsnprintf(string, BUFFSIZE, fmt, args); 
+
+	va_start(args, fmt);
+	vsnprintf(string, BUFFSIZE, fmt, args);
 	va_end(args);
-  
-	switch (version) { 
-		case 1: hashsize = do_md5(string, &hash); 
+
+	switch (version) {
+		case 1: hashsize = do_md5(string, &hash);
 			break;
-    
-		case 2: hashsize = do_sha(string, &hash); 
-			break; 
+
+		case 2: hashsize = do_sha(string, &hash);
+			break;
 	}
-  
-	if (hashsize == 0 || (result = (char *)malloc(hashsize * 2 + 1)) == NULL) { 
-		return NULL; 
+
+	if (hashsize == 0 || (result = (char *)malloc(hashsize * 2 + 1)) == NULL) {
+		return NULL;
 	}
-  
+
 	tmp = result;
-  
-	for(i = 0; i < hashsize; i++) { 
-		snprintf(tmp, 3, "%02x", hash[i]); 
-		tmp += 2; 
+
+	for(i = 0; i < hashsize; i++) {
+		snprintf(tmp, 3, "%02x", hash[i]);
+		tmp += 2;
 	}
-  
+
 	*tmp = '\0';
-  
+
 	return result;
 }
 
 
 char *progname(char *progpath)
-{ 
+{
 	char *progname = rindex(progpath, '/');
-  
-	if (progname == NULL) { 
-		progname = progpath; 
-	} 
-	else { 
-		progname++; 
-	} 
-	
+
+	if (progname == NULL) {
+		progname = progpath;
+	}
+	else {
+		progname++;
+	}
+
 	return progname;
 }
-
-void dbg(char *fmt, ...)
-{ 
-	va_list args; 
-	
-	if (debug) { 
-		char buffer[BUFFSIZE]; 
-		
-		memset(buffer, 0, BUFFSIZE); 
-		strcat(buffer, "DEBUG: "); 
-		va_start(args, fmt); 
-		vsnprintf(buffer, BUFFSIZE, fmt, args); 
-		va_end(args);
-    
-		if (debug_to_syslog) { 
-			syslog(LOG_DEBUG, buffer); 
-		}
-		else { 
-			printf(buffer); 
-		} 
-	}
-}
-
-
-

--- a/fw_touch.c
+++ b/fw_touch.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <syslog.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -19,23 +20,36 @@
 // and then runs the firewall reload script...
 //
 int fw_add_ip(struct in_addr ip, char *user)
-{ 
+{
 	FILE *fp;
+	struct stat st;
 	char path[512];
-  
+	char need_fw=0;
+
 	sprintf(path, "%s/%s", FW_DIRECTORY, inet_ntoa(ip));
+
+	// if IP has already been auth'd, simply touch the spool file but
+	// don't invoke dynfw again...
+	if (stat(path, &st) == -1) {
+		need_fw = 1;
+	}
 
 	// first create the ipaddr file in /var/spool/ipscromp...
 	//
-	if ((fp = fopen(path, "w")) == NULL) { 
-		syslog(LOG_ERR, "Unable to open '%s': %m", path); 
-		return -errno; 
+	if ((fp = fopen(path, "w")) == NULL) {
+		syslog(LOG_ERR, "Unable to open '%s': %m", path);
+		return -errno;
 	}
-  
-	fprintf(fp, "%s\n", user); 
-	fclose(fp); 
 
-	system("/etc/rc.fw > /dev/null 2> /dev/null");
-  
+	fprintf(fp, "%s\n", user);
+	fclose(fp);
+
+	if (need_fw) {
+		sprintf(path, "/usr/local/sbin/ipscromp_dynfw open %s > /dev/null 2>&1", inet_ntoa(ip));
+		system(path);
+	}
+
+	// system("/etc/rc.d/rc.fw > /dev/null 2> /dev/null");
+
 	return 0;
 }

--- a/in.ipscrompd.c
+++ b/in.ipscrompd.c
@@ -212,8 +212,8 @@ int main(int argc, char *argv[])
   }
   else 
   {
-    syslog(LOG_NOTICE, "User '%s' opened firewall for %s. Limit is %d hrs\n",
-           user, inet_ntoa(authreq.ip_to_add), rc);
+    syslog(LOG_NOTICE, "User '%s' opened firewall for %s.\n",
+           user, inet_ntoa(authreq.ip_to_add));
 
     if (rc == 0)
     {

--- a/ipscromp.c
+++ b/ipscromp.c
@@ -20,350 +20,306 @@
 
 char *ip_string(char *data)
 {
-  struct hostent *he;
+	struct hostent *he;
 
-  if (inet_aton(data, NULL) == 1)
-  {
-    return data;
-  }
+	if (inet_aton(data, NULL) == 1) {
+		return data;
+	}
 
-  if ((he = gethostbyname(data)) == NULL)
-  {
-    return NULL;
-  }
-
-  return strdup(inet_ntoa(*(struct in_addr *)he->h_addr));
+	if ((he = gethostbyname(data)) == NULL) {
+		return NULL;
+	}
+	return strdup(inet_ntoa(*(struct in_addr *)he->h_addr));
 }
+
 
 int connect_host(char *host, int port)
 {
-  int fd;
-  struct protoent *proto;
-  struct hostent *he;
-  struct sockaddr_in s;
+	int fd;
+	struct protoent *proto;
+	struct hostent *he;
+	struct sockaddr_in s;
 
-  memset(&s, 0, sizeof(s));
+	memset(&s, 0, sizeof(s));
 
-  if (inet_aton(host, &s.sin_addr) != 0)
-  {
-    /* Do nothing */
-  }
-  else if ((he = gethostbyname(host)) != NULL)
-  {
-    memcpy(&s.sin_addr, he->h_addr, he->h_length);
-  }
-  else
-  {
-    fprintf(stderr, "Unable to determine address of '%s'\n", host);
-    return -1;
-  }
+	if (inet_aton(host, &s.sin_addr) != 0) {
+		/* Do nothing */
+	}
+	else if ((he = gethostbyname(host)) != NULL) {
+		memcpy(&s.sin_addr, he->h_addr, he->h_length);
+	}
+	else {
+		fprintf(stderr, "Unable to determine address of '%s'\n", host);
+		return -1;
+	}
 
-  if ((proto = getprotobyname("tcp")) == NULL)
-  {
-    fprintf(stderr, "getprotobyname(\"tcp\") failed!\n");
-    return -2;
-  }
+	if ((proto = getprotobyname("tcp")) == NULL) {
+		fprintf(stderr, "getprotobyname(\"tcp\") failed!\n");
+		return -2;
+	}
 
-  if ((fd = socket(PF_INET, SOCK_STREAM, proto->p_proto)) < 0)
-  {
-    perror("socket()");
-    return -3;
-  }
+	if ((fd = socket(PF_INET, SOCK_STREAM, proto->p_proto)) < 0) {
+		perror("socket()");
+		return -3;
+	}
 
-  s.sin_family = PF_INET;
-  s.sin_port = htons(port);
+	s.sin_family = PF_INET;
+	s.sin_port = htons(port);
 
-  if (debug > 1)
-  {
-    dbg("connect_host() connecting to %s:%d\n",
-           inet_ntoa(s.sin_addr),
-           ntohs(s.sin_port));
-  }
+	if (debug > 1) {
+		dbg("connect_host() connecting to %s:%d\n",
+				inet_ntoa(s.sin_addr),
+				ntohs(s.sin_port));
+	}
 
-  if (connect(fd, (struct sockaddr *)&s, sizeof(s)) < 0)
-  {
-    perror("connect()");
-    close(fd);
-    return -4;
-  }
+	if (connect(fd, (struct sockaddr *)&s, sizeof(s)) < 0) {
+		perror("connect()");
+		close(fd);
+		return -4;
+	}
 
-  return fd;
+	return fd;
 }
+
 
 int find_port(char *host, char *default_service, int default_port)
 {
-  struct servent *se;
-  int port = -1;
-  char *preferred = NULL;
+	struct servent *se;
+	int port = -1;
+	char *preferred = NULL;
 
-  if (host != NULL && (preferred = rindex(host, ':')) != NULL)
-  {
-    *preferred = '\0';
-    preferred++;
-  }
+	if (host != NULL && (preferred = rindex(host, ':')) != NULL) {
+		*preferred = '\0';
+		preferred++;
+	}
 
-  if (preferred != NULL && (se = getservbyname(preferred, "tcp")) != NULL)
-  {
-    port = ntohs(se->s_port);
-  }
-  else if (preferred != NULL && (port = atoi(preferred)) > 0)
-  {
-    /* Do nothing */
-  }
-  else if (   default_service != NULL
-           && (se = getservbyname(default_service, "tcp")) != NULL)
-  {
-    port = ntohs(se->s_port);
-  }
-  else
-  {
-    port = default_port;
-  }
-
-  return port;
+	if (preferred != NULL && (se = getservbyname(preferred, "tcp")) != NULL) {
+		port = ntohs(se->s_port);
+	}
+	else if (preferred != NULL && (port = atoi(preferred)) > 0) {
+		/* Do nothing */
+	}
+	else if (   default_service != NULL
+		&& (se = getservbyname(default_service, "tcp")) != NULL) {
+		port = ntohs(se->s_port);
+	}
+	else {
+		port = default_port;
+	}
+	return port;
 }
+
 
 int set_echo(int enable)
 {
-  struct termios t;
+	struct termios t;
 
-  if(tcgetattr(fileno(stdin), &t) < 0)
-  {
-    perror("tcgetattr()");
-    return -1;
-  }
+	if (tcgetattr(fileno(stdin), &t) < 0) {
+		perror("tcgetattr()");
+		return -1;
+	}
 
-  if (enable)
-  {
-    t.c_lflag |= ECHO;
-  }
-  else
-  {
-    t.c_lflag &= (~ECHO);
-  }
+	if (enable) {
+		t.c_lflag |= ECHO;
+	} else {
+		t.c_lflag &= (~ECHO);
+	}
 
-  if(tcsetattr(fileno(stdin), TCSANOW, &t) < 0)
-  {
-    perror("tcsetattr()");
-    return -1;
-  }
-  return 0;
+	if (tcsetattr(fileno(stdin), TCSANOW, &t) < 0) {
+		perror("tcsetattr()");
+		return -1;
+	}
+
+	return 0;
 }
+
 
 void usage(char *progpath)
 {
-  printf("Usage: %s [options] [[<user>@]host[:<port>]] [..]\n"
-         "  Options:\n"
-         "    -1     : switch to version 1 (MD5) protocol\n"
-         "    -d     : enable debug messages\n"
-         "    -l user: specify user name if different from current\n"
-         "    -i ip  : specity alternate hostname or IP to open\n"
-         "\n",
-         progname(progpath)
-        );
+	printf("Usage: %s [options] [[<user>@]host[:<port>]] [..]\n"
+	       "  Options:\n"
+	       "    -1     : switch to version 1 (MD5) protocol\n"
+	       "    -d     : enable debug messages\n"
+	       "    -l user: specify user name if different from current\n"
+	       "    -p pass: specify passphrase\n"
+	       "    -i ip  : specity alternate hostname or IP to open\n"
+	       "\n",
+	       progname(progpath));
 }
+
 
 int connect_ipscrompd(char *host, char *dflt_user, char *password,
                       int version, char *alt_ip)
 {
-  char *challenge, *response,
-       *auth_str,  *at_symbol, *user = dflt_user;
+	char *challenge, *response,
+	     *auth_str,  *at_symbol, *user = dflt_user;
 
-  int port, auth_len, fd;
+	int port, auth_len, fd;
 
-  if ((at_symbol = index(host, '@')) != NULL)
-  {
-    user = malloc(at_symbol - host + 1);
-    if (user == NULL)
-    {
-      fprintf(stderr, "Unable to malloc() space for user string.\n");
-      return 1;
-    }
+	if ((at_symbol = index(host, '@')) != NULL) {
+		user = malloc(at_symbol - host + 1);
+		if (user == NULL) {
+			fprintf(stderr, "Unable to malloc() space for user string.\n");
+			return 1;
+		}
 
-    strncpy(user, host, at_symbol - host);
-    user[at_symbol - host] = '\0';
-    
-    host = at_symbol + 1;
-  }
+		strncpy(user, host, at_symbol - host);
+		user[at_symbol - host] = '\0';
+		host = at_symbol + 1;
+	}
 
 #ifdef __CYGWIN__
-  if (user == NULL)
-  {
-    user = cuserid(NULL);
-  }
+	if (user == NULL) {
+		user = cuserid(NULL);
+	}
 #endif
+	if (user == NULL) {
+		fprintf(stderr, "Cannot determine username; please use -l\n");
+		if (user != dflt_user) free(user);
+		return 2;
+	}
 
-  if (user == NULL)
-  {
-    fprintf(stderr, "Cannot determine username; please use -l\n");
-    if (user != dflt_user) free(user);
-    return 2;
-  }
+	port = find_port(host, DEFAULT_SERVICE, DEFAULT_PORT);
 
-  port = find_port(host, DEFAULT_SERVICE, DEFAULT_PORT);
+	dbg("Connecting to %s:%d\n", host, port);
 
-  dbg("Connecting to %s:%d\n", host, port);
+	if ((fd = connect_host(host, port)) < 0) {
+		if (user != dflt_user) free(user);
+		return 1;
+	}
 
-  if ((fd = connect_host(host, port)) < 0)
-  {
-    if (user != dflt_user) free(user);
-    return 1;
-  }
+	send_sock(fd, "USER %s %d\n", user, version);
 
-  send_sock(fd, "USER %s %d\n", user, version);
+	response = recv_sock(fd);
 
-  response = recv_sock(fd);
+	if (response == NULL) {
+		printf("Server closed connection instead of responding\n");
+		if (user != dflt_user) free(user);
+		close(fd);
+		return 1;
+	}
 
-  if (response == NULL)
-  {
-    printf("Server closed connection instead of responding\n");
-    if (user != dflt_user) free(user);
-    close(fd);
-    return 1;
-  }
+	if (strncmp(response, "AUTH ", 5) != 0) {
+		printf("Server responded incorrectly: '%s'\n", response);
+		if (user != dflt_user) free(user);
+		close(fd);
+		return 1;
+	}
 
-  if (strncmp(response, "AUTH ", 5) != 0)
-  {
-    printf("Server responded incorrectly: '%s'\n", response);
-    if (user != dflt_user) free(user);
-    close(fd);
-    return 1;
-  }
+	challenge = &response[5];
 
-  challenge = &response[5];
+	auth_len = strlen(user) + strlen(challenge) + strlen(password) + 3;
+	if (alt_ip != NULL) {
+		auth_len += strlen(alt_ip) + 1;
+	}
 
-  auth_len = strlen(user) + strlen(challenge) + strlen(password) + 3;
-  if (alt_ip != NULL)
-  {
-    auth_len += strlen(alt_ip) + 1;
-  }
+	if ((auth_str = malloc(auth_len)) == NULL) {
+		fprintf(stderr, "Unable to malloc() space for auth string.\n");
+		if (user != dflt_user) free(user);
+		close(fd);
+		return 1;
+	}
 
-  if ((auth_str = malloc(auth_len)) == NULL)
-  {
-    fprintf(stderr, "Unable to malloc() space for auth string.\n");
-    if (user != dflt_user) free(user);
-    close(fd);
-    return 1;
-  }
+	if (alt_ip == NULL) {
+		snprintf(auth_str, auth_len, "%s:%s:%s", user, challenge, password);
+	}
+	else {
+		snprintf(auth_str, auth_len, "%s:%s:%s:%s", user, alt_ip, challenge, password);
+	}
 
-  if (alt_ip == NULL)
-  {
-    snprintf(auth_str, auth_len, "%s:%s:%s",
-                                 user, challenge, password);
-  }
-  else
-  {
-    snprintf(auth_str, auth_len, "%s:%s:%s:%s",
-                                 user, alt_ip, challenge, password);
-  }
+	if (debug > 1) {
+		dbg("Auth string is: '%s'\n", auth_str);
+	}
 
-  if (debug > 1)
-  {
-    dbg("Auth string is: '%s'\n", auth_str);
-  }
+	if (alt_ip == NULL) {
+		send_sock(fd, "PERMIT %s\n", hash(version, auth_str));
+	}
+	else {
+		send_sock(fd, "IPERMIT %s %s\n", alt_ip, hash(version, auth_str));
+	}
 
-  if (alt_ip == NULL)
-  {
-    send_sock(fd, "PERMIT %s\n", hash(version, auth_str));
-  }
-  else
-  {
-    send_sock(fd, "IPERMIT %s %s\n", alt_ip, hash(version, auth_str));
-  }
+	response = recv_sock(fd);
+	close(fd);
 
-  response = recv_sock(fd);
-  close(fd);
-  if (user != dflt_user) free(user);
+	if (user != dflt_user) free(user);
 
-  if (strncmp(response, "OK ", 3) != 0)
-  {
-    printf("Server reports an error: '%s'\n", response);
-    return 1;
-  }
+	if (strncmp(response, "OK ", 3) != 0) {
+		printf("Server reports an error: '%s'\n", response);
+		return 1;
+	}
 
-  printf("%s\n", response);
-  return 0;
+	printf("%s\n", response);
+	return 0;
 }
+
 
 int main(int argc, char *argv[])
 {
-  int opt, version = 2, rc;
-  char *user = getlogin(),
-       *pass = NULL,
-       *alt_ip = NULL, *tmp;
+	int opt, version = 2, rc;
+	char *user = getlogin(),
+	     *pass = NULL,
+	     *alt_ip = NULL, *tmp;
 
-  while ((opt = getopt(argc, argv, "1dh:i:l:p:u:")) != EOF)
-  {
-    switch(opt)
-    {
-      case '1':
-        version = 1;
-        break;
+	while ((opt = getopt(argc, argv, "1dh:i:l:p:u:")) != EOF) {
+		switch(opt) {
+			case '1': version = 1;
+				  break;
 
-      case 'd':
-        debug++;
-        break;
+			case 'd': debug++;
+				  break;
 
-      case 'i':
-        alt_ip = optarg;
-        break;
+			case 'i': alt_ip = optarg;
+				  break;
 
-      case 'l':
-        user = optarg;
-        break;
+			case 'l': user = optarg;
+				  break;
 
-      case '?':
-        usage(argv[0]);
-        return 1;
-        break;
+			case 'p': pass = optarg;
+				  break;
 
-      default:
-        fprintf(stderr, "INTERNAL ERRROR: Untrapped getopt() char '%c'\n",
-                        opt);
-    }
-  }
+			case '?': usage(argv[0]);
+				  return 1;
+				  break;
 
-  if (alt_ip != NULL && version < 2)
-  {
-    fprintf(stderr, "WARNING: Alternative IP unsupported with old protocol\n");
-  }
+			default: fprintf(stderr, "INTERNAL ERRROR: Untrapped getopt() char '%c'\n", opt);
+		}
+	}
 
-  if (alt_ip != NULL)
-  {
-    tmp = ip_string(alt_ip);
-    if (tmp == NULL)
-    {
-      fprintf(stderr, "Cannot resolve '%s' to an IP address\n", alt_ip);
-      exit(1);
-    }
-    alt_ip = tmp;
-  }
+	if (alt_ip != NULL && version < 2) {
+		fprintf(stderr, "WARNING: Alternative IP unsupported with old protocol\n");
+	}
 
-  if (set_echo(0) < 0)
-  {
-    return 3;
-  }
+	if (alt_ip != NULL) {
+		tmp = ip_string(alt_ip);
+		if (tmp == NULL) {
+			fprintf(stderr, "Cannot resolve '%s' to an IP address\n", alt_ip);
+			exit(1);
+		}
+		alt_ip = tmp;
+	}
 
-  pass = ask_user("Your password: ");
-  printf("\n");
+	if (!pass) {
+		if (set_echo(0) < 0) {
+			return 3;
+		}
 
-  /* Do we really care if this fails? What can we do? */
-  set_echo(1);
+		pass = ask_user("Your password: ");
+		printf("\n");
 
-  rc = 0;
+		/* Do we really care if this fails? What can we do? */
+		set_echo(1);
+	}
 
-  if (argc - optind == 0)
-  {
-    rc += connect_ipscrompd(DEFAULT_HOST, user, pass, version, alt_ip);
-  }
-  else
-  {
-    for (; optind < argc; optind++)
-    {
-      rc += connect_ipscrompd(argv[optind], user, pass, version, alt_ip);
-    }
-  }
+	rc = 0;
 
-  return rc;
+	if (argc - optind == 0) {
+		rc += connect_ipscrompd(DEFAULT_HOST, user, pass, version, alt_ip);
+	}
+	else {
+		for (; optind < argc; optind++) {
+			rc += connect_ipscrompd(argv[optind], user, pass, version, alt_ip);
+		}
+	}
+	return rc;
 }
 

--- a/ipscromp_gatekeeper.c
+++ b/ipscromp_gatekeeper.c
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
 	DIR           *dir  = NULL;
 	struct dirent *dirp = NULL;
 	struct stat    statbuf;
-	char           fqfname[256], uid[256];
+	char           fqfname[300], dynfw[512], uid[256];
 	time_t         oldest;
 	struct timeval tv;
 
@@ -65,6 +65,9 @@ int main(int argc, char **argv)
 			printf("EXPIRING: %s (%s) \n", dirp->d_name, uid);
 			syslog(LOG_NOTICE, "Expiring: %s (%s)\n", dirp->d_name, uid);
 			unlink(fqfname);
+
+			sprintf(dynfw, "/usr/local/sbin/ipscromp_dynfw close %s > /dev/null 2>&1", dirp->d_name);
+			system(dynfw);
 		}
 	}
 

--- a/rc.fw.example
+++ b/rc.fw.example
@@ -1,0 +1,25 @@
+#!/bin/bash
+IPSCROMP_PORT='2002'
+
+
+# create a chain for ipscromp
+#
+echo "Config IPSCROMP chain..."
+/sbin/iptables -F IPSCROMP 2> /dev/null
+/sbin/iptables -X IPSCROMP 2> /dev/null
+/sbin/iptables -N IPSCROMP 2> /dev/null
+
+for i in $(ls /var/spool/ipscromp); do
+	/usr/local/sbin/ipscromp_dynfw open ${i}
+done
+/sbin/iptables -A IPSCROMP -j RETURN
+
+
+/sbin/iptables -A INPUT -j IPSCROMP
+
+# explicit allowances
+#
+
+# allow incoming ipscromp from anywhere
+/sbin/iptables -A INPUT -p tcp --dport $IPSCROMP_PORT -j ACCEPT
+

--- a/scripts/CVS/Entries
+++ b/scripts/CVS/Entries
@@ -1,4 +1,0 @@
-/ipscromp_dynfw/1.2/Fri Nov 15 21:09:04 2013//
-/ipscromp_export/1.2/Sat Nov 16 13:53:44 2013//
-/ipscromp_unexport/1.2/Sat Nov 16 13:53:22 2013//
-D

--- a/scripts/CVS/Repository
+++ b/scripts/CVS/Repository
@@ -1,1 +1,0 @@
-ipscromp/scripts

--- a/scripts/CVS/Root
+++ b/scripts/CVS/Root
@@ -1,1 +1,0 @@
-jimmiem@labrat.lexington.ibm.com:/usr/local/cvsroot/jimmiem

--- a/scripts/ipscromp_crontab
+++ b/scripts/ipscromp_crontab
@@ -1,0 +1,7 @@
+# the following will periodically revoke ipscromp auths
+#
+
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
+0-59 * * * * root /usr/local/sbin/ipscromp_gatekeeper 600 > /dev/null 2>&1
+

--- a/scripts/ipscromp_dynfw
+++ b/scripts/ipscromp_dynfw
@@ -1,25 +1,76 @@
 #!/bin/bash
 #
-# this script is called from /etc/rc.fw
+# this script is invoked from ipscromp_gatekeeper
+# until we decide on which ports we want to open, just open all of them...
 #
-# it will run 'gatekeeper' to clean up expired IP addressses
-# it will then explicitly open the firewall for those addresses not expired
-#
-# the baler version of ipscromp modified the main firewall script on the fly.  
-# i don't like that.
-#
+# usage:
+#    ipscromp_dynfw [open|close] <IP>
+
 
 REPO=/var/spool/ipscromp
 
-IPSCROMP_PORTS="22"
+SSH_PORT='22'
 
-/usr/local/sbin/ipscromp_gatekeeper $1
 
-for i in `ls $REPO`
-do
-	# until we decide on a set of ports to allow, we'll open all ports...
+usage()
+{
+	cat <<EOF
+usage: ipscromp_dynfw [open|close] <IP addr>
 
-	#/sbin/iptables -A INPUT -p tcp -m multiport --ports $IPSCROMP_PORTS -s $i/32   -j ACCEPT 
-	#/sbin/iptables -A INPUT -p udp -m multiport --ports $IPSCROMP_PORTS -s $i/32   -j ACCEPT 
-	/sbin/iptables -A INPUT -s $i/32 -j ACCEPT
+EOF
+}
+
+
+open_firewall()
+{
+	#echo "open_firewall for $1"
+	EXISTS=$(iptables -C IPSCROMP -s $1 -j ACCEPT 2>&1)
+	[ ! -z "$EXISTS" ] && iptables -I IPSCROMP -s $1 -j ACCEPT
+}
+
+
+close_firewall()
+{
+	#echo "close_firewall for $1"
+	iptables -D IPSCROMP -s $1 -j ACCEPT
+}
+
+
+op=""
+
+while test $# -gt 0; do
+	case "$1" in
+		open)
+			shift
+			op=open
+			ipaddr="$1"
+			;;
+
+		close)
+			shift
+			op=close
+			ipaddr="$1"
+			;;
+	esac
+	shift
 done
+
+if [ -z "$op" ]; then
+	usage
+	exit
+fi
+
+if [ -z "$ipaddr" ]; then
+	usage
+	exit
+fi
+
+
+if [ "$op" = "open" ]; then
+	echo "Opening FW for $ipaddr..."
+	open_firewall $ipaddr
+else
+	echo "Closing FW for $ipaddr..."
+	close_firewall $ipaddr
+fi
+

--- a/scripts/ipscromp_xinetd
+++ b/scripts/ipscromp_xinetd
@@ -1,0 +1,14 @@
+service ipscrompd
+{ 
+        port                    = 2002
+        socket_type             = stream
+        protocol                = tcp
+        user                    = root
+        wait                    = no
+        server                  = /usr/local/sbin/in.ipscrompd
+        type                    = UNLISTED
+	flags                   = IPv4
+        log_type                = SYSLOG daemon
+        log_on_success          += HOST
+        log_on_failure          += HOST
+}


### PR DESCRIPTION
- changes to the way ipscromp interacts with the firewall firewall is expected to have an IPSCROMP chain.  ipscromp_dynfw script adds/deletes IPs from this chain.  see rc.fw.example file.

- prevent in.ipscrompd from adding multiple identical rules to IPSCROMP chain

- ipscromp daemon now invokes ipscromp_dynfw instead of reloading the entire firewall script.

- some whitespace changes