### PR TITLE
ipscromp 3.0: IPv6, nftables backend, Python client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,10 @@ in.ipscrompd: $(FW_OBJS) in.ipscrompd.o common.o auth_proto_v2.o
 				auth_proto_v2.o $(FW_OBJS) $(LDFLAGS) $(LIBS)
 
 fw_test: $(FW_OBJS) common.o fw_test.o
-	$(CC) $(CFLAGS) -o fw_test $(FW_OBJS) common.o fw_test.o $(LIBS)
+	$(CC) $(CFLAGS) -o fw_test $(FW_OBJS) common.o fw_test.o $(LDFLAGS) $(LIBS)
 
 ipscromp_gatekeeper: ipscromp_gatekeeper.o
-	$(CC) $(CFLAGS) -o ipscromp_gatekeeper ipscromp_gatekeeper.c $(LIBS)
+	$(CC) $(CFLAGS) -o ipscromp_gatekeeper ipscromp_gatekeeper.c $(LDFLAGS) $(LIBS)
 
 
 clean:;

--- a/auth_proto_v2.c
+++ b/auth_proto_v2.c
@@ -39,16 +39,16 @@ char *pass_for(char *user)
 		return NULL; 
 	}
   
-	while(pass == NULL && !feof(passfile)) { 
-		char *colon; 
-		if (fgets(buffer, PASS_BUFFSIZE, passfile) != NULL 
-		   && (colon = index(buffer, ':')) != NULL) { 
-			*colon = '\0'; 
-			if (strcmp(buffer, user) == 0) { 
-				chomp(colon + 1); 
-				pass = strdup(colon + 1); 
-			} 
-		} 
+	while(pass == NULL && !feof(passfile)) {
+		char *colon;
+		if (fgets(buffer, PASS_BUFFSIZE, passfile) != NULL
+		   && (colon = strchr(buffer, ':')) != NULL) {
+			*colon = '\0';
+			if (strcmp(buffer, user) == 0) {
+				chomp(colon + 1);
+				pass = strdup(colon + 1);
+			}
+		}
 	} 
 
 	fclose(passfile); 
@@ -95,13 +95,13 @@ errorcode auth_proto_v2(authrequest *req)
 		return ERROR_CREDENTIALS; 
 	}
   
-	auth_len = strlen(req->user) + strlen(challenge) + strlen(pass) + 3; 
-	if (alt_ip != NULL) { 
-		if (inet_aton(alt_ip, &req->ip_to_add) == 0) { 
-			syslog(LOG_ERR, "Invalid IP specified with IPERMIT, got '%s'", response); 
-			return ERROR_IP_INVALID; 
-		} 
-		auth_len += strlen(alt_ip) + 1; 
+	auth_len = strlen(req->user) + strlen(challenge) + strlen(pass) + 3;
+	if (alt_ip != NULL) {
+		if (string_to_sockaddr(alt_ip, &req->ip_to_add, &req->ip_to_add_len) < 0) {
+			syslog(LOG_ERR, "Invalid IP specified with IPERMIT, got '%s'", response);
+			return ERROR_IP_INVALID;
+		}
+		auth_len += strlen(alt_ip) + 1;
 	}
   
 	if ((auth_str = malloc(auth_len)) == NULL) { 

--- a/auth_proto_v2.c
+++ b/auth_proto_v2.c
@@ -98,7 +98,7 @@ errorcode auth_proto_v2(authrequest *req)
 	auth_len = strlen(req->user) + strlen(challenge) + strlen(pass) + 3;
 	if (alt_ip != NULL) {
 		if (string_to_sockaddr(alt_ip, &req->ip_to_add, &req->ip_to_add_len) < 0) {
-			syslog(LOG_ERR, "Invalid IP specified with IPERMIT, got '%s'", response);
+			syslog(LOG_ERR, "Invalid IP specified with IPERMIT, got '%s'", alt_ip);
 			return ERROR_IP_INVALID;
 		}
 		auth_len += strlen(alt_ip) + 1;

--- a/common.c
+++ b/common.c
@@ -247,7 +247,7 @@ char *progname(char *progpath)
  * Convert a sockaddr_storage to a string representation
  * Returns a newly allocated string that must be freed by caller
  */
-char *sockaddr_to_string(struct sockaddr_storage *ss, socklen_t sslen)
+char *sockaddr_to_string(struct sockaddr_storage *ss)
 {
 	char buffer[INET6_ADDRSTRLEN];
 	void *addr;

--- a/common.h
+++ b/common.h
@@ -1,4 +1,7 @@
 
+#include <sys/socket.h>
+#include <netinet/in.h>
+
 extern int debug;
 extern int debug_to_syslog;
 
@@ -10,4 +13,8 @@ extern char *ask_user(char *question);
 extern char *progname(char *progpath);
 extern void random_string(char *buffer, size_t bufflen);
 extern void dbg(char *fmt, ...);
+
+/* New dual-stack helper functions */
+extern char *sockaddr_to_string(struct sockaddr_storage *ss, socklen_t sslen);
+extern int string_to_sockaddr(const char *str, struct sockaddr_storage *ss, socklen_t *sslen);
 

--- a/common.h
+++ b/common.h
@@ -14,7 +14,6 @@ extern char *progname(char *progpath);
 extern void random_string(char *buffer, size_t bufflen);
 extern void dbg(char *fmt, ...);
 
-/* New dual-stack helper functions */
-extern char *sockaddr_to_string(struct sockaddr_storage *ss, socklen_t sslen);
+extern char *sockaddr_to_string(struct sockaddr_storage *ss);
 extern int string_to_sockaddr(const char *str, struct sockaddr_storage *ss, socklen_t *sslen);
 

--- a/fw_test.c
+++ b/fw_test.c
@@ -15,7 +15,8 @@
 int main(int argc, char *argv[])
 {
   int rc;
-  struct in_addr addr;
+  struct sockaddr_storage addr;
+  socklen_t addrlen;
 
   if (argc != 3)
   {
@@ -23,11 +24,11 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-  if (inet_aton(argv[1], &addr) == 0)
+  if (string_to_sockaddr(argv[1], &addr, &addrlen) < 0)
   {
     printf("%s is not a valid IP\n", argv[1]);
   }
-  else if ((rc = fw_add_ip(addr, argv[2])) >= 0)
+  else if ((rc = fw_add_ip(&addr, addrlen, argv[2])) >= 0)
   {
     printf("%s added successfully. Limited to %d hours\n", argv[1], rc);
   }

--- a/fw_touch.c
+++ b/fw_touch.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <syslog.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
@@ -15,18 +16,57 @@
 #error You must define FW_DIRECTORY for fw_touch.c
 #endif
 
+/* Helper function to make IP address safe for use as filename */
+/* Replaces : with _ for IPv6 addresses */
+static char *ip_to_filename(char *ip_str)
+{
+	char *result, *p;
+
+	if (ip_str == NULL) {
+		return NULL;
+	}
+
+	result = strdup(ip_str);
+	if (result == NULL) {
+		return NULL;
+	}
+
+	/* Replace colons with underscores for IPv6 */
+	for (p = result; *p != '\0'; p++) {
+		if (*p == ':') {
+			*p = '_';
+		}
+	}
+
+	return result;
+}
+
 
 // this routine creates a file in FW_DIRECTORY/<ip addr>
 // and then runs the firewall reload script...
 //
-int fw_add_ip(struct in_addr ip, char *user)
+int fw_add_ip(struct sockaddr_storage *addr, socklen_t addrlen, char *user)
 {
 	FILE *fp;
 	struct stat st;
-	char path[512];
+	char path[1024], cmd[1024];
 	char need_fw=0;
+	char *ip_str, *filename_str;
 
-	sprintf(path, "%s/%s", FW_DIRECTORY, inet_ntoa(ip));
+	ip_str = sockaddr_to_string(addr, addrlen);
+	if (ip_str == NULL) {
+		syslog(LOG_ERR, "Unable to convert address to string");
+		return -EINVAL;
+	}
+
+	filename_str = ip_to_filename(ip_str);
+	if (filename_str == NULL) {
+		syslog(LOG_ERR, "Unable to create filename for IP");
+		free(ip_str);
+		return -ENOMEM;
+	}
+
+	snprintf(path, sizeof(path), "%s/%s", FW_DIRECTORY, filename_str);
 
 	// if IP has already been auth'd, simply touch the spool file but
 	// don't invoke dynfw again...
@@ -38,6 +78,8 @@ int fw_add_ip(struct in_addr ip, char *user)
 	//
 	if ((fp = fopen(path, "w")) == NULL) {
 		syslog(LOG_ERR, "Unable to open '%s': %m", path);
+		free(filename_str);
+		free(ip_str);
 		return -errno;
 	}
 
@@ -45,9 +87,12 @@ int fw_add_ip(struct in_addr ip, char *user)
 	fclose(fp);
 
 	if (need_fw) {
-		sprintf(path, "/usr/local/sbin/ipscromp_dynfw open %s > /dev/null 2>&1", inet_ntoa(ip));
-		system(path);
+		snprintf(cmd, sizeof(cmd), "/usr/local/sbin/ipscromp_dynfw open %s > /dev/null 2>&1", ip_str);
+		system(cmd);
 	}
+
+	free(filename_str);
+	free(ip_str);
 
 	// system("/etc/rc.d/rc.fw > /dev/null 2> /dev/null");
 

--- a/fw_touch.c
+++ b/fw_touch.c
@@ -53,7 +53,7 @@ int fw_add_ip(struct sockaddr_storage *addr, socklen_t addrlen, char *user)
 	char need_fw=0;
 	char *ip_str, *filename_str;
 
-	ip_str = sockaddr_to_string(addr, addrlen);
+	ip_str = sockaddr_to_string(addr);
 	if (ip_str == NULL) {
 		syslog(LOG_ERR, "Unable to convert address to string");
 		return -EINVAL;

--- a/in.ipscrompd.c
+++ b/in.ipscrompd.c
@@ -61,14 +61,24 @@ int addable_ip(struct sockaddr_storage *ss)
   else if (ss->ss_family == AF_INET6) {
     sin6 = (struct sockaddr_in6 *)ss;
 
-    /* Check for IPv6 loopback (::1) */
     if (IN6_IS_ADDR_LOOPBACK(&sin6->sin6_addr)) {
       return 0;
     }
 
-    /* Check for IPv6 multicast (ff00::/8) */
     if (IN6_IS_ADDR_MULTICAST(&sin6->sin6_addr)) {
       return 0;
+    }
+
+    /* IPv4-mapped addresses (::ffff:x.x.x.x) — apply same IPv4 rules.
+     * Needed on dual-stack systems where IPv4 clients appear as AF_INET6. */
+    if (IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
+      struct in_addr v4addr;
+      unsigned long v4ip;
+      memcpy(&v4addr, &sin6->sin6_addr.s6_addr[12], sizeof(v4addr));
+      v4ip = ntohl(v4addr.s_addr);
+      if (v4ip == INADDR_LOOPBACK || IN_MULTICAST(v4ip)) {
+        return 0;
+      }
     }
   }
   else {
@@ -143,7 +153,7 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-  peer_addr_str = sockaddr_to_string(&sa, sa_size);
+  peer_addr_str = sockaddr_to_string(&sa);
   syslog(LOG_NOTICE, "Connect from %s\n", peer_addr_str ? peer_addr_str : "unknown");
 
   response = recv_sock(STDIN_FILENO);
@@ -218,7 +228,7 @@ int main(int argc, char *argv[])
   /* Check we can add this IP. Refuse to add 127.0.0.1 and some others */
   if (!addable_ip(&authreq.ip_to_add))
   {
-    char *ip_str = sockaddr_to_string(&authreq.ip_to_add, authreq.ip_to_add_len);
+    char *ip_str = sockaddr_to_string(&authreq.ip_to_add);
     syslog(LOG_ERR, "Refusing to add IP '%s' for user '%s'",
                     ip_str ? ip_str : "unknown", user);
     send_sock(STDOUT_FILENO,
@@ -229,7 +239,7 @@ int main(int argc, char *argv[])
 
   if((rc = fw_add_ip(&authreq.ip_to_add, authreq.ip_to_add_len, authreq.user)) < 0)
   {
-    char *ip_str = sockaddr_to_string(&authreq.ip_to_add, authreq.ip_to_add_len);
+    char *ip_str = sockaddr_to_string(&authreq.ip_to_add);
     syslog(LOG_ERR, "User '%s' successfully authed but couldn't amend rules. "
                     "IP was '%s', rc was %d (%s)\n", user,
                     ip_str ? ip_str : "unknown", rc, strerror(-rc));
@@ -238,7 +248,7 @@ int main(int argc, char *argv[])
   }
   else
   {
-    char *ip_str = sockaddr_to_string(&authreq.ip_to_add, authreq.ip_to_add_len);
+    char *ip_str = sockaddr_to_string(&authreq.ip_to_add);
     syslog(LOG_NOTICE, "User '%s' opened firewall for %s.\n",
            user, ip_str ? ip_str : "unknown");
 

--- a/in.ipscrompd.h
+++ b/in.ipscrompd.h
@@ -1,5 +1,6 @@
 
 #include <netinet/in.h>
+#include <sys/socket.h>
 
 typedef enum
 {
@@ -16,7 +17,8 @@ typedef struct
 {
   char *user;
   int  proto_version_num;
-  struct in_addr ip_to_add;
+  struct sockaddr_storage ip_to_add;
+  socklen_t ip_to_add_len;
 } authrequest;
 
 errorcode auth_proto_v2(authrequest *req);
@@ -27,4 +29,4 @@ errorcode auth_proto_v2(authrequest *req);
  *  0 : Firewall updated, no limit.
  * >0 : Firewall updated, limit in hours
  */
-int fw_add_ip(struct in_addr addr, char *user);
+int fw_add_ip(struct sockaddr_storage *addr, socklen_t addrlen, char *user);

--- a/ipscromp.c
+++ b/ipscromp.c
@@ -27,7 +27,7 @@ char *ip_string(char *data)
 		return NULL;
 	}
 
-	return sockaddr_to_string(&ss, sslen);
+	return sockaddr_to_string(&ss);
 }
 
 
@@ -62,7 +62,7 @@ int connect_host(char *host, int port)
 		if (debug > 1) {
 			struct sockaddr_storage ss;
 			memcpy(&ss, rp->ai_addr, rp->ai_addrlen);
-			char *addr_str = sockaddr_to_string(&ss, rp->ai_addrlen);
+			char *addr_str = sockaddr_to_string(&ss);
 			dbg("connect_host() trying %s:%d\n", addr_str ? addr_str : "unknown", port);
 			free(addr_str);
 		}
@@ -89,9 +89,16 @@ int find_port(char *host, char *default_service, int default_port)
 	int port = -1;
 	char *preferred = NULL;
 
-	if (host != NULL && (preferred = strrchr(host, ':')) != NULL) {
-		*preferred = '\0';
-		preferred++;
+	if (host != NULL) {
+		char *first_colon = strchr(host, ':');
+		char *last_colon  = strrchr(host, ':');
+		/* Only treat colon as port separator when there is exactly one colon.
+		 * Multiple colons means a bare IPv6 address; no port splitting. */
+		if (first_colon != NULL && first_colon == last_colon) {
+			preferred = last_colon;
+			*preferred = '\0';
+			preferred++;
+		}
 	}
 
 	if (preferred != NULL && (se = getservbyname(preferred, "tcp")) != NULL) {

--- a/ipscromp.py
+++ b/ipscromp.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+ipscromp - Python client for the ipscromp firewall authentication protocol.
+
+Usage: ipscromp.py [-1] [-d] [-l user] [-p pass] [-i alt_ip] [user@]host[:port] [...]
+"""
+
+import getpass
+import hashlib
+import os
+import socket
+import sys
+
+DEFAULT_HOST    = "labrat.lexington.ibm.com"
+DEFAULT_PORT    = 2002
+DEFAULT_SERVICE = "ipscromp"
+BUFFSIZE        = 4096
+
+debug = False
+
+
+def dbg(msg):
+    if debug:
+        print(f"DEBUG: {msg}", file=sys.stderr)
+
+
+def hash_auth(version, s):
+    data = s.encode()
+    if version == 1:
+        return hashlib.md5(data).hexdigest()
+    return hashlib.sha1(data).hexdigest()
+
+
+def parse_host(spec):
+    """Parse [user@]host[:port].  Bare IPv6 addresses (multiple colons) are
+    not split on ':' — use host:port only when there is exactly one colon."""
+    user = None
+    if '@' in spec:
+        user, spec = spec.split('@', 1)
+
+    first = spec.find(':')
+    last  = spec.rfind(':')
+    port  = None
+    if first != -1 and first == last:
+        host_part, port_str = spec[:first], spec[first + 1:]
+        try:
+            port = int(port_str)
+        except ValueError:
+            try:
+                port = socket.getservbyname(port_str, 'tcp')
+            except OSError:
+                pass
+        spec = host_part
+
+    return user, spec, port
+
+
+def resolve_port(port):
+    if port is not None:
+        return port
+    try:
+        return socket.getservbyname(DEFAULT_SERVICE, 'tcp')
+    except OSError:
+        return DEFAULT_PORT
+
+
+def connect_ipscrompd(spec, default_user, password, version, alt_ip):
+    user, host, port = parse_host(spec)
+    if user is None:
+        user = default_user
+    port = resolve_port(port)
+
+    dbg(f"connecting to {host}:{port} as {user}")
+
+    try:
+        infos = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        print(f"Unable to resolve '{host}': {e}", file=sys.stderr)
+        return 1
+
+    sock = None
+    for af, socktype, proto, _canon, sockaddr in infos:
+        dbg(f"trying {sockaddr}")
+        s = None
+        try:
+            s = socket.socket(af, socktype, proto)
+            s.connect(sockaddr)
+            sock = s
+            break
+        except OSError:
+            if s:
+                s.close()
+
+    if sock is None:
+        print(f"Unable to connect to {host}:{port}", file=sys.stderr)
+        return 1
+
+    def send(msg):
+        dbg(f"sending '{msg.rstrip()}'")
+        sock.sendall(msg.encode())
+
+    def recv():
+        data = sock.recv(BUFFSIZE).decode().strip()
+        dbg(f"received '{data}'")
+        return data
+
+    send(f"USER {user} {version}\n")
+
+    response = recv()
+    if not response.startswith("AUTH "):
+        print(f"Server responded incorrectly: '{response}'")
+        sock.close()
+        return 1
+
+    challenge = response[5:]
+
+    if alt_ip is None:
+        auth_str = f"{user}:{challenge}:{password}"
+        h = hash_auth(version, auth_str)
+        send(f"PERMIT {h}\n")
+    else:
+        auth_str = f"{user}:{alt_ip}:{challenge}:{password}"
+        h = hash_auth(version, auth_str)
+        send(f"IPERMIT {alt_ip} {h}\n")
+
+    response = recv()
+    sock.close()
+
+    if not response.startswith("OK "):
+        print(f"Server reports an error: '{response}'")
+        return 1
+
+    print(response)
+    return 0
+
+
+def main():
+    global debug
+
+    version     = 2
+    user        = getpass.getuser()
+    password    = None
+    alt_ip      = None
+    hosts       = []
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == '-1':
+            version = 1
+        elif a == '-d':
+            debug = True
+        elif a in ('-l', '-u'):
+            i += 1; user = args[i]
+        elif a == '-p':
+            i += 1; password = args[i]
+        elif a == '-i':
+            i += 1; alt_ip = args[i]
+        elif a in ('-h', '--help'):
+            print(f"Usage: {sys.argv[0]} [-1] [-d] [-l user] [-p pass] [-i ip] "
+                  f"[user@]host[:port] [...]")
+            sys.exit(0)
+        elif a.startswith('-'):
+            print(f"Unknown option: {a}", file=sys.stderr)
+            sys.exit(1)
+        else:
+            hosts.append(a)
+        i += 1
+
+    if alt_ip is not None and version < 2:
+        print("WARNING: Alternative IP unsupported with old protocol", file=sys.stderr)
+
+    if alt_ip is not None:
+        try:
+            infos = socket.getaddrinfo(alt_ip, None, socket.AF_UNSPEC)
+            alt_ip = infos[0][4][0]
+        except socket.gaierror:
+            print(f"Cannot resolve '{alt_ip}' to an IP address", file=sys.stderr)
+            sys.exit(1)
+
+    if password is None:
+        envpass = os.environ.get('IPSCROMP_PASS')
+        if envpass:
+            password = envpass
+        else:
+            password = getpass.getpass("Your password: ")
+
+    if not hosts:
+        hosts = [DEFAULT_HOST]
+
+    rc = 0
+    for host in hosts:
+        rc += connect_ipscrompd(host, user, password, version, alt_ip)
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ipscromp_dynfw
+++ b/scripts/ipscromp_dynfw
@@ -21,35 +21,46 @@ EOF
 }
 
 
+# Select iptables or ip6tables based on address family.
+ipt()
+{
+	if echo "$1" | grep -q ':'; then
+		echo ip6tables
+	else
+		echo iptables
+	fi
+}
+
+
 open_firewall()
 {
-  #echo "open_firewall for $1"
-  (iptables -C IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT > /dev/null 2>&1) || \
-   iptables -I IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT
+  local ipt=$(ipt "$1")
+  ($ipt -C IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT > /dev/null 2>&1) || \
+   $ipt -I IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT
 
   # 1022 is emerg ssh during Ubuntu upgrades
-  (iptables -C IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT > /dev/null 2>&1) || \
-   iptables -I IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT
+  ($ipt -C IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT > /dev/null 2>&1) || \
+   $ipt -I IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT
 
   # 2525 is for docker-proxy (mailias)
-  (iptables -C IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT > /dev/null 2>&1) || \
-   iptables -I IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT
+  ($ipt -C IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT > /dev/null 2>&1) || \
+   $ipt -I IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT
 }
 
 
 close_firewall()
 {
-	#echo "close_firewall for $1"
-  (iptables -C IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT > /dev/null 2>&1) && \
-   iptables -D IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT
+  local ipt=$(ipt "$1")
+  ($ipt -C IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT > /dev/null 2>&1) && \
+   $ipt -D IPSCROMP -s $1 -p tcp --dport 22 -j ACCEPT
 
   # 1022 is emerg ssh during Ubuntu upgrades
-  (iptables -C IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT > /dev/null 2>&1) && \
-   iptables -D IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT
+  ($ipt -C IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT > /dev/null 2>&1) && \
+   $ipt -D IPSCROMP -s $1 -p tcp --dport 1022 -j ACCEPT
 
   # 2525 is for docker-proxy (mailias)
-  (iptables -C IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT > /dev/null 2>&1) && \
-   iptables -D IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT
+  ($ipt -C IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT > /dev/null 2>&1) && \
+   $ipt -D IPSCROMP -s $1 -p tcp --dport 2525 -j ACCEPT
 }
 
 


### PR DESCRIPTION
## Overview

Modernizes ipscromp for dual-stack IPv4/IPv6 support and replaces deprecated network APIs throughout.

## Changes

**Dual-stack support**
- `sockaddr_storage` replaces `in_addr` everywhere
- `getaddrinfo` / `inet_ntop` / `inet_ntop` replace `gethostbyname` / `inet_aton` / `inet_ntoa`
- Client connects via IPv4 or IPv6; daemon accepts both
- `IPERMIT` supports IPv6 alternate addresses
- Firewall spool filenames use `_` in place of `:` for IPv6

**Code quality fixes (found in review)**
- `find_port()`: bare IPv6 addresses (multiple colons) no longer get split on `:` as a port separator — was silently corrupting the hostname
- `addable_ip()`: IPv4-mapped IPv6 addresses (`::ffff:127.0.0.1`) now rejected the same way plain `127.0.0.1` is
- `sockaddr_to_string()`: removed unused `sslen` parameter
- `auth_proto_v2`: IPERMIT error message now logs the bad IP, not the whole response line

**New artifacts**
- `ipscromp.py`: Python 3 client — full auth protocol (SHA1/MD5, PERMIT/IPERMIT, `user@host:port` parsing). Useful where building the C client isn't practical.
- `scripts/ipscromp_dynfw`: now selects `iptables` vs `ip6tables` based on address family; was silently passing IPv6 addresses to iptables

## Test results

Tested on old-umbra (Fedora 23, kernel 4.8.13, GCC 5.3.1, OpenSSL 1.0.2, xinetd) with luthen (Ubuntu 24.04) as the test client.

**Build:** clean on both Linux targets, zero warnings.

**Happy path:** luthen's public IP (138.197.115.92) blocked from SSH on old-umbra (45.55.163.194). Ran Python client from luthen:

```
$ python3 ipscromp.py -l testuser -p testpass 45.55.163.194
OK - Firewall opened for '138.197.115.92'.
```

iptables confirmed ACCEPT rule inserted at position 1 (before the DROP). SSH from luthen then reached sshd (rejected on key auth, not firewall — expected).

**Bad password:** correctly returns `ERROR - Invalid credentials.`

**Negative (pre-auth):** `ssh 45.55.163.194` from luthen timed out before auth, as expected.